### PR TITLE
Remove versions on document clone

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -115,6 +115,13 @@ module Mongoid
 
     private
 
+    def clone_document
+      attrs = as_document.__deep_copy__
+      attrs["version"] = 1 if attrs.delete("versions")
+      process_localized_attributes(attrs)
+      attrs
+    end
+
     # Find the previous version of this document in the database, or if the
     # document had been saved without versioning return the persisted one.
     #

--- a/spec/mongoid/versioning_spec.rb
+++ b/spec/mongoid/versioning_spec.rb
@@ -497,4 +497,30 @@ describe Mongoid::Versioning do
     end
   end
 
+  describe ".clone" do
+
+    context "when document is not persisted" do
+
+      let(:wiki) do
+        WikiPage.new
+      end
+
+      context "when versions exists" do
+
+        before do
+          wiki[:versions] = [ { title: "1" } ]
+        end
+
+        let(:copy) { wiki.clone }
+
+        it "does not copy the versions" do
+          expect(copy.versions).to eq([])
+        end
+
+        it "resets the document version" do
+          expect(copy.version).to eq(1)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I just removed a remaining `versions` code on clone method. see https://github.com/mongoid/mongoid/commit/248b60ebc3174e0e031c1aa49ab7977d8e78e53a

So I am adding that behaviour in here.

review @simi
