### PR TITLE
fix test to match by id instead of titles

### DIFF
--- a/spec/mongoid/versioning_spec.rb
+++ b/spec/mongoid/versioning_spec.rb
@@ -197,6 +197,8 @@ describe Mongoid::Versioning do
         WikiPage.with(database: "mongoid_test_alt").create!(description: "1",title: title)
       end
 
+      let(:page_id){ page.id}
+
       context "when the document is persisted once" do
 
         it "returns 1" do
@@ -225,11 +227,11 @@ describe Mongoid::Versioning do
         end
 
         it "persists to specified database" do
-          expect(WikiPage.with(database: "mongoid_test_alt").find_by(:title => title)).to_not be_nil
+          expect(WikiPage.with(database: "mongoid_test_alt").find(page_id)).to_not be_nil
         end
 
         it "persists the versions to specified database" do
-          expect(WikiPage.with(database: "mongoid_test_alt").find_by(:title => title).version).to eq(4)
+          expect(WikiPage.with(database: "mongoid_test_alt").find(page_id).version).to eq(4)
         end
       end
     end


### PR DESCRIPTION
I tested this gem with mongoid 5. All tests ran perfectly fine except one. When I read the failed test I noticed the matching criteria is error prone as there were multiple documents in the database with the same title and you were looking by title instead of id which is unique.
