### PR TITLE
fix mongoid5 api changes

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -132,7 +132,7 @@ module Mongoid
     def clone_document
       attrs = as_document.__deep_copy__
       attrs["version"] = 1 if attrs.delete("versions")
-      process_localized_attributes(attrs)
+      process_localized_attributes(self, attrs)
       attrs
     end
 
@@ -148,7 +148,7 @@ module Mongoid
     def previous_revision
       _loading_revision do
         self.class.unscoped.
-          with(self.mongo_session.options).
+          with(self.mongo_client.options).
           where(_id: id).
           any_of({ version: version }, { version: nil }).first
       end


### PR DESCRIPTION
1. fix in clone_document as process_localized_attributes has an extra param
2. replace deprecated mongo_session with mongo_client

I'm not sure if this gem supposed to support mongoid 5.x. Please feel free to close this if that's not the case.